### PR TITLE
Added return type to avoid `void` return type in AbstractEncoder method

### DIFF
--- a/src/binary/BinaryEncoder.ts
+++ b/src/binary/BinaryEncoder.ts
@@ -38,11 +38,11 @@ export class BinaryEncoder {
         return BinaryEncoder._VERSIONS;
     }
 
-    public encodeDataFromRLR(rawLocationReference: RawLocationReference) {
+    public encodeDataFromRLR(rawLocationReference: RawLocationReference): LocationReference {
         return this.encodeDataFromRLRAndVersion(rawLocationReference, BinaryEncoder._VERSIONS[BinaryEncoder._VERSIONS.length - 1]);
     }
 
-    public encodeDataFromRLRAndVersion(rawLocationReference: RawLocationReference, version: number) {
+    public encodeDataFromRLRAndVersion(rawLocationReference: RawLocationReference, version: number): LocationReference {
         const locationType = rawLocationReference.getLocationType();
         if (!this._checkVersion(version, locationType)) {
             return LocationReference.fromValues(rawLocationReference.getId(), BinaryReturnCode.INVALID_VERSION, locationType, version);

--- a/src/binary/encoder/AbstractEncoder.ts
+++ b/src/binary/encoder/AbstractEncoder.ts
@@ -35,13 +35,14 @@ import { SideOfRoad, getId as sideOfRoadGetId } from '../../data/location/data/S
 import { Orientation, getId as orientationGetId } from '../../data/location/data/Orientation';
 import { AbsoluteCoordinates } from '../data/AbsoluteCoordinates';
 import { RelativeCoordinates } from '../data/RelativeCoordinates';
+import { LocationReference } from '../../data/LocationReference';
 import { RawLocationReference } from '../../data/raw-location-reference/RawLocationReference';
 import { Offsets } from '../../data/Offsets';
 import { LocationReferencePoint } from '../../data/LocationReferencePoint';
 import { GeoCoordinates } from '../../map/GeoCoordinates';
 
 export class AbstractEncoder {
-    public encodeData(rawLocationReference: RawLocationReference, version: number) {
+    public encodeData(rawLocationReference: RawLocationReference, version: number): LocationReference {
         throw new Error('This method is abstract');
     }
 


### PR DESCRIPTION
Due to the AbstractEncoder not declaring a return type and throwing an exception, the resulting return type is void | LocationReference instead of just LocationReference and user must treat a case that never happens.